### PR TITLE
feat: Re-enable table of contents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -435,7 +435,7 @@ function App() {
   // Pass null for tableOfContents to hide it
   return (
     <Layout
-      tableOfContents={null}
+      tableOfContents={<TableOfContents items={tocItems} activeItem={currentPath} />}
     >
       <Routes>
         <Route path="/" element={


### PR DESCRIPTION
The table of contents was previously disabled by passing `null` to the `tableOfContents` prop in the `Layout` component. This change re-enables it by passing the `TableOfContents` component with the necessary props.